### PR TITLE
fix: use ralt for layer toggle on windows

### DIFF
--- a/modules/shared/kanata/hrm.kbd
+++ b/modules/shared/kanata/hrm.kbd
@@ -1,7 +1,7 @@
 (defsrc
   esc
   caps   a   s   d   f   j   k   l   ;
-  fn
+  ralt
 )
 
 (defvar
@@ -35,7 +35,7 @@
 (deflayer fn
   @tl
   caps  _  _  _  _  _  _  _  _
-  fn
+  ralt
 )
 
 (deffakekeys
@@ -53,7 +53,7 @@
     (on-idle-fakekey to-base tap 20)
   )
 
-  fnl (tap-hold $tap-time $hold-time fn (layer-toggle fn))
+  fnl (tap-hold $tap-time $hold-time ralt (layer-toggle fn))
   caps (tap-hold $tap-time $hold-time esc lctl)
   a (tap-hold-release-keys $tap-time $hold-time (multi a @tap) lmet $left-hand-keys)
   s (tap-hold-release-keys $tap-time $hold-time (multi s @tap) lalt $left-hand-keys)


### PR DESCRIPTION
## Summary
- Replace `fn` with `ralt` in shared kanata config — `fn` is firmware-level on Windows and not visible to kanata
- `ralt` tap sends ralt, hold toggles fn layer, `ralt+esc` toggles base/nomods

## Test plan
- [ ] Run setup.ps1 on Windows, verify kanata starts without config errors
- [ ] Verify ralt+esc toggles between HRM and plain typing